### PR TITLE
Fix/resizing window crash

### DIFF
--- a/include/Engine/Event/Event.hpp
+++ b/include/Engine/Event/Event.hpp
@@ -25,6 +25,11 @@ namespace eng
                 Mouse::Button button;
             };
 
+            struct ResizeEvent {
+                uint32_t height;
+                uint32_t width;
+            };
+
             enum class Type
             {
                 MouseButton
@@ -35,6 +40,7 @@ namespace eng
             union
             {
                 MouseButtonEvent mouseButton;
+                ResizeEvent resize;
             };
     };
 }

--- a/include/Engine/Rendering/RenderTarget.hpp
+++ b/include/Engine/Rendering/RenderTarget.hpp
@@ -28,13 +28,15 @@ namespace eng
             void draw(const Vertex3D *_vtx, size_t _size, VertexArray::Type _type);
 
             virtual [[nodiscard]] Point2<uint32_t> getSize() const = 0;
+            [[nodiscard]] Camera &getCamera();
 
             void clear(const Color &_clr = { 0, 0, 0, 255 });
 
         protected:
             RenderTarget() = default;
 
-            void create(uint32_t _x, uint32_t _y, const Camera& _cam = Camera(), uint8_t _bpp = 32);
+            void create(uint32_t _x, uint32_t _y, const Camera& _cam, uint8_t _bpp = 32);
+            void create(uint32_t _x, uint32_t _y, uint8_t _bpp = 32);
 
             [[nodiscard]] uint8_t *getData() const;
 

--- a/include/Engine/Rendering/RenderWindow.hpp
+++ b/include/Engine/Rendering/RenderWindow.hpp
@@ -20,7 +20,10 @@ namespace eng
         protected:
             void render(HDC _draw) const;
 
+            void onResize(const Event &_event) override;
+
         private:
             Camera m_cam;
+            Point2<uint32_t> m_size;
     };
 }

--- a/include/Engine/System/Window.hpp
+++ b/include/Engine/System/Window.hpp
@@ -34,12 +34,15 @@ namespace eng
             void setSize(uint32_t _x, uint32_t _y);
             [[nodiscard]] Point2<uint32_t> getSize() const;
 
-            bool pollEvent(Event &_event);
+            bool pollEvent(Event &_event);  
 
             void close();
 
         protected:
             [[nodiscard]] HWND getWindow() const;
+
+            bool resized(uint64_t _lparam, int64_t _wparam, Event &_event);
+            virtual void onResize(const Event &_event);
 
         private:
             static LRESULT CALLBACK WIN_proc(HWND _win, UINT _msg, WPARAM _wparam, LPARAM _lparam);

--- a/include/Engine/System/Window.hpp
+++ b/include/Engine/System/Window.hpp
@@ -34,15 +34,16 @@ namespace eng
             void setSize(uint32_t _x, uint32_t _y);
             [[nodiscard]] Point2<uint32_t> getSize() const;
 
-            bool pollEvent(Event &_event);  
 
             void close();
 
         protected:
+            void disptachEvent();
+
             [[nodiscard]] HWND getWindow() const;
 
             bool resized(uint64_t _lparam, int64_t _wparam, Event &_event);
-            virtual void onResize(const Event &_event);
+            virtual void onResize(Event &_event);
 
         private:
             static LRESULT CALLBACK WIN_proc(HWND _win, UINT _msg, WPARAM _wparam, LPARAM _lparam);

--- a/src/Engine/Rendering/RenderTarget.cpp
+++ b/src/Engine/Rendering/RenderTarget.cpp
@@ -81,7 +81,12 @@ namespace eng
 
         for (; ystart < yend; ystart++)
             triRangeApply(vtx.data(), ystart, triRange(vtx.data(), ystart), _txtr);
-     }
+    }
+
+    Camera &RenderTarget::getCamera()
+    {
+        return m_cam;
+    }
 
     void RenderTarget::clear(const Color &_clr)
     {
@@ -99,10 +104,15 @@ namespace eng
 
     void RenderTarget::create(uint32_t _x, uint32_t _y, const Camera &_cam, uint8_t _bpp)
     {
+        m_cam = _cam;
+        create(_x, _y, _bpp);
+    }
+
+    void RenderTarget::create(uint32_t _x, uint32_t _y, uint8_t _bpp)
+    {
         HDC hdc = GetDC(NULL);
         BITMAPINFO bmi;
-
-        m_cam = _cam;
+        
         m_bpp = _bpp;
         bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
         bmi.bmiHeader.biWidth = _x;
@@ -112,6 +122,7 @@ namespace eng
         bmi.bmiHeader.biCompression = BI_RGB;
         m_dib = CreateDIBSection(hdc, &bmi, DIB_RGB_COLORS, reinterpret_cast<void **>(&m_data), NULL, NULL);
         ReleaseDC(NULL, hdc);
+        m_depth.clear();
         m_depth.resize(_x * _y, std::numeric_limits<float>::lowest());
     }
 

--- a/src/Engine/Rendering/RenderWindow.cpp
+++ b/src/Engine/Rendering/RenderWindow.cpp
@@ -10,11 +10,10 @@ namespace eng
         : Window(_x, _y, _title)
     {
         Point2<uint32_t> size = getSize();
-        Camera cam{};
 
-        cam.setFov(110.f).setRange(0.1f, 100.f).setSize(static_cast<float>(size.x), static_cast<float>(size.y)).move({ 0, 0, -10 });
-        m_size = size;
-        create(m_size.y, m_size.x, cam);
+        getCamera().setFov(110.f).setRange(0.1f, 100.f).setSize(static_cast<float>(size.x), static_cast<float>(size.y)).move({ 0, 0, -10 });
+        m_size = { _x, _y };
+        create(m_size.y, m_size.x);
     }
 
     Point2<uint32_t> RenderWindow::getSize() const

--- a/src/Engine/Rendering/RenderWindow.cpp
+++ b/src/Engine/Rendering/RenderWindow.cpp
@@ -2,6 +2,8 @@
 #include "Engine/Rendering/RenderWindow.hpp"
 #include "Engine/Rendering/Sprite.hpp"
 
+#include <iostream>
+
 namespace eng
 {
     RenderWindow::RenderWindow(uint32_t _x, uint32_t _y, const std::string &_title)
@@ -11,12 +13,13 @@ namespace eng
         Camera cam{};
 
         cam.setFov(110.f).setRange(0.1f, 100.f).setSize(static_cast<float>(size.x), static_cast<float>(size.y)).move({ 0, 0, -10 });
-        create(size.y, size.x, cam);
+        m_size = size;
+        create(m_size.y, m_size.x, cam);
     }
 
     Point2<uint32_t> RenderWindow::getSize() const
     {
-        return Window::getSize();
+        return m_size;
     }
 
     void RenderWindow::setCamera(const Camera &_cam)
@@ -27,6 +30,13 @@ namespace eng
     void RenderWindow::display()
     {
         InvalidateRect(getWindow(), NULL, FALSE);
+    }
+
+    void RenderWindow::onResize(const Event &_event)
+    {
+        m_size = { _event.resize.width, _event.resize.height };
+        create(_event.resize.width, _event.resize.height);
+        getCamera().setSize(static_cast<float>(_event.resize.width), static_cast<float>(_event.resize.height));
     }
 
     void RenderWindow::render(HDC _draw) const


### PR DESCRIPTION
Fix:
- Resize a `Window` doesn't crash anymore

Breaking change:
- `Window::poolEvent` is change to `Window::handleEvent` and is now in protected access.